### PR TITLE
Add kairo-admin dashboard and kairo-kdocs integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
   id("kairo-sample")
   id("kairo-sample-application")
+  id("kairo-sample-dokka")
   id("kairo-sample-ksp")
 }
 
 dependencies {
   runtimeOnly(libs.gcpSocketFactory.r2dbc)
+  api(libs.kairo.admin)
   api(libs.kairo.application)
   api(libs.kairo.config)
   api(libs.kairo.coroutines)
@@ -15,6 +17,7 @@ dependencies {
   api(libs.kairo.gcpSecretSupplier)
   api(libs.kairo.healthCheck.feature)
   api(libs.kairo.id)
+  api(libs.kairo.kdocs)
   api(libs.kairo.logging)
   api(libs.kairo.optional)
   api(libs.kairo.protectedString)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
   val kotlinVersion = "2.3.0"
   implementation(kotlin("gradle-plugin", kotlinVersion))
 
+  // https://github.com/Kotlin/dokka/releases
+  val dokkaVersion = "2.0.0"
+  implementation("org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion")
+
   // https://github.com/google/ksp/releases
   val kspVersion = "2.3.4"
   implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kspVersion")

--- a/buildSrc/src/main/kotlin/kairo-sample-dokka.gradle.kts
+++ b/buildSrc/src/main/kotlin/kairo-sample-dokka.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.jetbrains.dokka")
+}
+
+tasks.register<Sync>("packageKdocs") {
+  dependsOn(rootProject.tasks.named("dokkaGenerate"))
+  from(rootProject.layout.buildDirectory.dir("dokka/html"))
+  into(layout.buildDirectory.dir("resources/main/static/kdocs"))
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ flyway-postgres = { module = "org.flywaydb:flyway-database-postgresql", version.
 gcpSocketFactory-jdbc = { module = "com.google.cloud.sql:postgres-socket-factory" }
 gcpSocketFactory-r2dbc = { module = "com.google.cloud.sql:cloud-sql-connector-r2dbc-postgres" }
 
+kairo-admin = { module = "software.airborne.kairo:kairo-admin" }
 kairo-application = { module = "software.airborne.kairo:kairo-application" }
 kairo-config = { module = "software.airborne.kairo:kairo-config" }
 kairo-coroutines = { module = "software.airborne.kairo:kairo-coroutines" }
@@ -25,6 +26,7 @@ kairo-healthCheck-feature = { module = "software.airborne.kairo:kairo-health-che
 kairo-id = { module = "software.airborne.kairo:kairo-id" }
 kairo-integrationTesting = { module = "software.airborne.kairo:kairo-integration-testing" }
 kairo-integrationTesting-postgres = { module = "software.airborne.kairo:kairo-integration-testing-postgres" }
+kairo-kdocs = { module = "software.airborne.kairo:kairo-kdocs" }
 kairo-logging = { module = "software.airborne.kairo:kairo-logging" }
 kairo-optional = { module = "software.airborne.kairo:kairo-optional" }
 kairo-protectedString = { module = "software.airborne.kairo:kairo-protected-string" }

--- a/src/main/kotlin/kairoSample/Main.kt
+++ b/src/main/kotlin/kairoSample/Main.kt
@@ -1,5 +1,7 @@
 package kairoSample
 
+import kairo.admin.AdminDashboardConfig
+import kairo.admin.AdminDashboardFeature
 import kairo.application.kairo
 import kairo.config.ConfigResolver
 import kairo.config.loadConfig
@@ -8,6 +10,7 @@ import kairo.gcpSecretSupplier.DefaultGcpSecretSupplier
 import kairo.gcpSecretSupplier.GcpSecretSupplier
 import kairo.healthCheck.HealthCheck
 import kairo.healthCheck.HealthCheckFeature
+import kairo.kdocs.KdocsFeature
 import kairo.protectedString.ProtectedString
 import kairo.rest.RestFeature
 import kairo.rest.auth.koin
@@ -68,6 +71,13 @@ fun main() {
         },
       ),
       StytchFeature(config.stytch),
+      KdocsFeature(),
+      AdminDashboardFeature(
+        config = AdminDashboardConfig(
+          serverName = "Kairo Sample",
+          githubRepoUrl = "https://github.com/hudson155/kairo-sample",
+        ),
+      ),
     )
 
     val server = Server(

--- a/src/main/kotlin/kairoSample/Main.kt
+++ b/src/main/kotlin/kairoSample/Main.kt
@@ -77,6 +77,7 @@ fun main() {
           serverName = "Kairo Sample",
           githubRepoUrl = "https://github.com/hudson155/kairo-sample",
         ),
+        // TODO: Add auth to ensure the admin dashboard is only available to authorized parties.
       ),
     )
 


### PR DESCRIPTION
## Summary
- Adds `kairo-admin` and `kairo-kdocs` dependencies to demonstrate how easy it is to integrate the new admin dashboard and Dokka-powered API docs into a Kairo application
- Creates a `kairo-sample-dokka` convention plugin (mirrors the `kairo-service-dokka` plugin from [kairo#1149](https://github.com/hudson155/kairo/pull/1149)) to generate and package KDocs into the classpath
- Wires up `KdocsFeature` and `AdminDashboardFeature` in `Main.kt` — dashboard available at `/_admin`, docs at `/_kdocs`

## Test plan
- [ ] Verify Gradle sync succeeds once kairo-admin and kairo-kdocs artifacts are published
- [ ] Run the app locally and confirm the admin dashboard loads at `/_admin`
- [ ] Run `./gradlew dokkaGenerate :packageKdocs` and confirm KDocs are served at `/_kdocs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)